### PR TITLE
Updated track table and releases route now returns all releases

### DIFF
--- a/data/migrations/20200418232154_create-spotify-tables.js
+++ b/data/migrations/20200418232154_create-spotify-tables.js
@@ -27,6 +27,12 @@ exports.up = function(knex) {
             .notNullable();
         table.text('privateUrl')
             .notNullable();
+        table.integer('duration')
+            .notNullable();
+        table.boolean('explicit')
+            .notNullable();
+        table.text('previewUrl')
+            .notNullable();
   })
   .createTable('Artists', table => {
         table.text('id')

--- a/routes/spotifyRouter.js
+++ b/routes/spotifyRouter.js
@@ -138,37 +138,35 @@ router.get('/releases', async (req, res) => {
         const albumArtists = {};
         const albumTracks = {};
         for(let i=0; i<albums.length; i++){
-            if(!albums[i].isHidden){
-                /**
-                 * Create an object for key=album_id, value=[artist_id]
-                 * {
-                 *  albumId: [artist_id],
-                 *  ...
-                 * }
-                 */
-                albumArtists[albums[i].id] = await Spotify.getArtistsIdByAlbum(albums[i].id);
+            /**
+             * Create an object for key=album_id, value=[artist_id]
+             * {
+             *  albumId: [artist_id],
+             *  ...
+             * }
+             */
+            albumArtists[albums[i].id] = await Spotify.getArtistsIdByAlbum(albums[i].id);
 
-                /**
-                 * Create an object for key=album_id, value=[track_id]
-                 * {
-                 *  albumId: [track_id],
-                 *  ...
-                 * }
-                 */
-                albumTracks[albums[i].id] = await Spotify.getTracksIdByAlbum(albums[i].id);
+            /**
+             * Create an object for key=album_id, value=[track_id]
+             * {
+             *  albumId: [track_id],
+             *  ...
+             * }
+             */
+            albumTracks[albums[i].id] = await Spotify.getTracksIdByAlbum(albums[i].id);
 
-                returnData.push({
-                    albumId: albums[i].id,
-                    albumName: albums[i].name,
-                    albumImgUrl: albums[i].imgUrl,
-                    albumPublicUrl: albums[i].externalUrl,
-                    albumPrivateUrl: albums[i].privateUrl,
-                    albumReleaseDate: albums[i].releaseDate,
-                    isHidden: albums[i].isHidden,
-                    artists: [],
-                    tracks: []
-                })
-            }
+            returnData.push({
+                albumId: albums[i].id,
+                albumName: albums[i].name,
+                albumImgUrl: albums[i].imgUrl,
+                albumPublicUrl: albums[i].externalUrl,
+                albumPrivateUrl: albums[i].privateUrl,
+                albumReleaseDate: albums[i].releaseDate,
+                isHidden: albums[i].isHidden,
+                artists: [],
+                tracks: []
+            })
         }
 
         for(let i=0; i<returnData.length; i++){


### PR DESCRIPTION
**Before**
/releases route would only return releases that weren't hidden. 
Tracks table only contained img url, private url, and public url.

**Now**
/releases route returns all tracks
Tracks table now contains previous properties + duration, explicit, and preview url.